### PR TITLE
Implement JSON-RPC daemon server and structured logging

### DIFF
--- a/dg_core/src/dg_core/daemon/__init__.py
+++ b/dg_core/src/dg_core/daemon/__init__.py
@@ -1,0 +1,21 @@
+"""Daemon utilities for DG Core."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from .log_stream import get_log_stream
+
+__all__ = ["DaemonServer", "get_log_stream", "main"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper
+    if name in {"DaemonServer", "main"}:
+        from .server import DaemonServer, main
+
+        globals().update({"DaemonServer": DaemonServer, "main": main})
+        return globals()[name]
+    raise AttributeError(name)
+
+
+if TYPE_CHECKING:  # pragma: no cover - typing aid
+    from .server import DaemonServer, main  # noqa: F401

--- a/dg_core/src/dg_core/daemon/log_stream.py
+++ b/dg_core/src/dg_core/daemon/log_stream.py
@@ -1,0 +1,134 @@
+"""Utilities for streaming DG Core logs to connected clients."""
+from __future__ import annotations
+
+import asyncio
+from asyncio import Queue
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Callable, Deque, Dict, Iterable
+
+
+@dataclass(slots=True)
+class LogSubscription:
+    """Asynchronous iterator over log records."""
+
+    _stream: "LogStream"
+    _queue: Queue[Dict[str, Any]]
+    _closed: bool = False
+
+    def __aiter__(self) -> "LogSubscription":
+        return self
+
+    async def __anext__(self) -> Dict[str, Any]:
+        if self._closed:
+            raise StopAsyncIteration
+        try:
+            record = await self._queue.get()
+        except asyncio.CancelledError:  # pragma: no cover - cooperative cancellation
+            self._closed = True
+            raise
+        if record is _SENTINEL:
+            self._closed = True
+            raise StopAsyncIteration
+        return record
+
+    async def aclose(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        await self._stream._remove(self._queue)
+
+
+_SentinelType = object
+_SENTINEL = _SentinelType()
+
+
+class LogStream:
+    """Fan-out publisher for structured log records."""
+
+    def __init__(self, *, max_queue: int = 256, backlog: int = 128) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._subscribers: Dict[int, Queue[Dict[str, Any]]] = {}
+        self._max_queue = max_queue
+        self._backlog: Deque[Dict[str, Any]] = deque(maxlen=backlog)
+        self._pending: Deque[Dict[str, Any]] = deque(maxlen=backlog)
+
+    def attach_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        while self._pending:
+            record = self._pending.popleft()
+            self._dispatch(record)
+
+    def publish(self, record: Dict[str, Any]) -> None:
+        payload = dict(record)
+        self._backlog.append(payload)
+        if self._loop is None:
+            self._pending.append(payload)
+            return
+        self._loop.call_soon_threadsafe(self._dispatch, payload)
+
+    def subscribe(self) -> LogSubscription:
+        if self._loop is None:
+            raise RuntimeError("Log stream not attached to an event loop")
+        queue: Queue[Dict[str, Any]] = Queue(maxsize=self._max_queue)
+        # prime the queue with the backlog without exceeding maxsize
+        for item in list(self._backlog)[-self._max_queue :]:
+            if queue.full():
+                break
+            queue.put_nowait(item)
+        self._subscribers[id(queue)] = queue
+        return LogSubscription(self, queue)
+
+    async def _remove(self, queue: Queue[Dict[str, Any]]) -> None:
+        self._subscribers.pop(id(queue), None)
+        try:
+            queue.put_nowait(_SENTINEL)  # type: ignore[arg-type]
+        except asyncio.QueueFull:
+            pass
+
+    def _dispatch(self, record: Dict[str, Any]) -> None:
+        for queue in list(self._subscribers.values()):
+            self._enqueue(queue, record)
+
+    def _enqueue(self, queue: Queue[Dict[str, Any]], record: Dict[str, Any]) -> None:
+        try:
+            queue.put_nowait(record)
+        except asyncio.QueueFull:
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:  # pragma: no cover - race
+                pass
+            try:
+                queue.put_nowait(record)
+            except asyncio.QueueFull:  # pragma: no cover - still full after drop
+                pass
+
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+    @property
+    def backlog(self) -> Iterable[Dict[str, Any]]:
+        return tuple(self._backlog)
+
+
+_GLOBAL_LOG_STREAM = LogStream()
+
+
+def get_log_stream() -> LogStream:
+    """Return the singleton log stream."""
+
+    return _GLOBAL_LOG_STREAM
+
+
+def stream_processor(stream: LogStream) -> Callable[[Any, str, Dict[str, Any]], Dict[str, Any]]:
+    """Return a structlog processor that publishes to ``stream``."""
+
+    def processor(_logger: Any, _method: str, event_dict: Dict[str, Any]) -> Dict[str, Any]:
+        stream.publish(event_dict)
+        return event_dict
+
+    return processor
+
+
+__all__ = ["LogStream", "LogSubscription", "get_log_stream", "stream_processor"]

--- a/dg_core/src/dg_core/daemon/protocol.py
+++ b/dg_core/src/dg_core/daemon/protocol.py
@@ -1,0 +1,189 @@
+"""JSON-RPC protocol helpers for the DG Core daemon."""
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Mapping, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+IDType = int | str | None
+
+
+class JSONRPCError(BaseModel):
+    """JSON-RPC error payload."""
+
+    code: int
+    message: str
+    data: Any | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class JSONRPCRequest(BaseModel):
+    """Incoming JSON-RPC request."""
+
+    jsonrpc: str = Field(default="2.0")
+    id: IDType = None
+    method: str
+    params: Mapping[str, Any] | list[Any] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class JSONRPCResponse(BaseModel):
+    """Standard JSON-RPC response payload."""
+
+    jsonrpc: str = Field(default="2.0")
+    id: IDType = None
+    result: Any | None = None
+    error: JSONRPCError | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class JSONRPCNotification(BaseModel):
+    """JSON-RPC notification payload."""
+
+    jsonrpc: str = Field(default="2.0")
+    method: str
+    params: Mapping[str, Any] | list[Any] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ProtocolError(Exception):
+    """Raised when a message cannot be parsed."""
+
+
+class RPCError(Exception):
+    """Raised by method handlers to signal JSON-RPC errors."""
+
+    def __init__(self, code: int, message: str, *, data: Any | None = None) -> None:
+        super().__init__(message)
+        self.error = JSONRPCError(code=code, message=message, data=data)
+
+
+class MethodNotFound(RPCError):
+    def __init__(self, method: str) -> None:
+        super().__init__(-32601, "Method not found", data=method)
+
+
+class InvalidParams(RPCError):
+    def __init__(self, message: str, data: Any | None = None) -> None:
+        super().__init__(-32602, message, data=data)
+
+
+@dataclass(slots=True)
+class MethodContext:
+    """Context passed to registered method handlers."""
+
+    server: Any
+    connection: Any
+
+
+@dataclass(slots=True)
+class MethodResult:
+    """Result container for method dispatch."""
+
+    result: Any | None = None
+    stream: str | None = None
+
+
+class MethodHandler(Protocol):
+    def __call__(self, context: MethodContext, params: Dict[str, Any]) -> Any:  # pragma: no cover - protocol
+        ...
+
+
+class MethodRegistry:
+    """Registry for mapping JSON-RPC methods to callables."""
+
+    def __init__(self) -> None:
+        self._handlers: Dict[str, MethodHandler] = {}
+
+    def register(self, name: str, handler: MethodHandler) -> None:
+        if name in self._handlers:
+            raise ValueError(f"Handler already registered for {name}")
+        self._handlers[name] = handler
+
+    def method(self, name: str) -> Callable[[MethodHandler], MethodHandler]:
+        def decorator(func: MethodHandler) -> MethodHandler:
+            self.register(name, func)
+            return func
+
+        return decorator
+
+    async def dispatch(self, context: MethodContext, request: JSONRPCRequest) -> MethodResult:
+        handler = self._handlers.get(request.method)
+        if not handler:
+            raise MethodNotFound(request.method)
+        params = _coerce_params(request)
+        try:
+            result = handler(context, params)
+            if isinstance(result, MethodResult):
+                return result
+            if inspect.isawaitable(result):
+                awaited = await result  # type: ignore[func-returns-value]
+                if isinstance(awaited, MethodResult):
+                    return awaited
+                return MethodResult(result=awaited)
+            return MethodResult(result=result)
+        except RPCError:
+            raise
+        except ValidationError as exc:  # pragma: no cover - defensive
+            raise InvalidParams("Invalid parameters", data=exc.errors()) from exc
+        except Exception as exc:  # pragma: no cover - defensive
+            raise RPCError(-32603, "Internal error", data=str(exc)) from exc
+
+
+def parse_request(payload: str) -> JSONRPCRequest:
+    """Parse a JSON string into a :class:`JSONRPCRequest`."""
+
+    try:
+        return JSONRPCRequest.model_validate_json(payload)
+    except ValidationError as exc:
+        raise ProtocolError(str(exc)) from exc
+
+
+def make_response(request: JSONRPCRequest, result: Any) -> JSONRPCResponse:
+    """Create a JSON-RPC success response."""
+
+    return JSONRPCResponse(id=request.id, result=result)
+
+
+def make_error_response(request: JSONRPCRequest | None, error: JSONRPCError) -> JSONRPCResponse:
+    """Create a JSON-RPC error response."""
+
+    return JSONRPCResponse(id=request.id if request else None, error=error)
+
+
+def _coerce_params(request: JSONRPCRequest) -> Dict[str, Any]:
+    params = request.params
+    if params is None:
+        return {}
+    if isinstance(params, Mapping):
+        return dict(params)
+    if isinstance(params, list):
+        if len(params) == 1 and isinstance(params[0], Mapping):
+            return dict(params[0])
+        raise InvalidParams("Positional parameters are not supported", data=params)
+    raise InvalidParams("Parameters must be an object or null", data=params)
+
+
+__all__ = [
+    "IDType",
+    "JSONRPCError",
+    "JSONRPCRequest",
+    "JSONRPCResponse",
+    "JSONRPCNotification",
+    "MethodContext",
+    "MethodRegistry",
+    "MethodResult",
+    "ProtocolError",
+    "RPCError",
+    "MethodNotFound",
+    "InvalidParams",
+    "parse_request",
+    "make_response",
+    "make_error_response",
+]

--- a/dg_core/src/dg_core/daemon/server.py
+++ b/dg_core/src/dg_core/daemon/server.py
@@ -1,0 +1,400 @@
+"""Async daemon server exposing DG Core functionality."""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import structlog
+
+from pydantic import ValidationError
+
+from ..policy import PolicyDocument, PolicyEngine, policy_from_path
+from ..redactor.engines import RedactionEngine
+from ..scanner import Scanner, ScannerConfig, scan_text
+from ..utils.text import to_text
+from ..version import __version__
+from ..ipc.transport import BaseConnection, ConnectionClosed, NamedPipeTransport, UnixSocketTransport
+from ..logging import configure_logging
+from .log_stream import get_log_stream
+from .protocol import (
+    JSONRPCError,
+    JSONRPCNotification,
+    JSONRPCRequest,
+    JSONRPCResponse,
+    InvalidParams,
+    MethodContext,
+    MethodRegistry,
+    MethodResult,
+    ProtocolError,
+    RPCError,
+    make_error_response,
+    make_response,
+    parse_request,
+)
+
+_MAX_REQUEST_BYTES = 512 * 1024
+_REQUEST_TIMEOUT = 15.0
+_LOG_STREAM_NAME = "logs"
+_DEFAULT_PIPE = r"\\\\.\\pipe\\DataGuardianIPC"
+_DEFAULT_SOCKET = Path.home() / ".local/share/data_guardian/ipc.sock"
+
+logger = structlog.get_logger(__name__)
+
+
+class DaemonServer:
+    """JSON-RPC daemon orchestrating DG Core business logic."""
+
+    def __init__(
+        self,
+        *,
+        socket_path: Path | None = None,
+        pipe_name: str | None = None,
+        max_request_bytes: int = _MAX_REQUEST_BYTES,
+        request_timeout: float = _REQUEST_TIMEOUT,
+    ) -> None:
+        self._max_request_bytes = max_request_bytes
+        self._request_timeout = request_timeout
+        self._shutdown = asyncio.Event()
+        self._log_stream = get_log_stream()
+        self._scanner = Scanner()
+        self._default_policy_path = (
+            Path(__file__).resolve().parents[2] / "policies" / "default.yaml"
+        )
+        self._default_policy = policy_from_path(self._default_policy_path)
+        self._policy_engine = PolicyEngine(self._default_policy)
+        self._redactor = RedactionEngine(self._policy_engine)
+        self._registry = MethodRegistry()
+        self._start_time = time.monotonic()
+        self._request_count = 0
+        self._connections: set[int] = set()
+        self._transport = self._create_transport(socket_path=socket_path, pipe_name=pipe_name)
+        self._register_methods()
+
+    async def serve_forever(self) -> None:
+        loop = asyncio.get_running_loop()
+        self._log_stream.attach_loop(loop)
+        endpoint = self.endpoint
+        logger.info("daemon.start", endpoint=str(endpoint))
+        await self._transport.start(self._handle_connection)
+        await self._shutdown.wait()
+        await self._transport.close()
+        logger.info("daemon.stop")
+
+    async def stop(self) -> None:
+        self._shutdown.set()
+
+    @property
+    def endpoint(self) -> Path | str:
+        if isinstance(self._transport, UnixSocketTransport):
+            return self._transport.path
+        if isinstance(self._transport, NamedPipeTransport):
+            return self._transport.pipe_name
+        return "unknown"
+
+    def _create_transport(
+        self, *, socket_path: Path | None, pipe_name: str | None
+    ) -> NamedPipeTransport | UnixSocketTransport:
+        if sys.platform == "win32":
+            name = pipe_name or _DEFAULT_PIPE
+            return NamedPipeTransport(name)
+        path = Path(socket_path or _DEFAULT_SOCKET)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return UnixSocketTransport(path)
+
+    async def _handle_connection(self, connection: BaseConnection) -> None:
+        conn_id = id(connection)
+        self._connections.add(conn_id)
+        logger.info("daemon.connection.opened", connection=conn_id)
+        tasks: set[asyncio.Task[Any]] = set()
+        subscriptions: list[Any] = []
+        try:
+            while not self._shutdown.is_set():
+                try:
+                    payload = await asyncio.wait_for(
+                        connection.receive(), timeout=self._request_timeout
+                    )
+                except asyncio.TimeoutError:
+                    timeout = JSONRPCResponse(
+                        error=JSONRPCError(code=-32000, message="Request timed out"),
+                        id=None,
+                    )
+                    await connection.send(timeout.model_dump_json())
+                    continue
+                except ConnectionClosed:
+                    break
+
+                if not payload:
+                    continue
+                if len(payload.encode("utf-8")) > self._max_request_bytes:
+                    error = JSONRPCResponse(
+                        error=JSONRPCError(
+                            code=-32600,
+                            message="Request too large",
+                            data=len(payload),
+                        ),
+                        id=None,
+                    )
+                    await connection.send(error.model_dump_json())
+                    continue
+
+                response_payload = await self._dispatch_request(
+                    connection, payload, tasks, subscriptions
+                )
+                if response_payload is not None:
+                    await connection.send(response_payload)
+        finally:
+            for task in tasks:
+                task.cancel()
+            for subscription in subscriptions:
+                try:
+                    await subscription.aclose()
+                except Exception:  # pragma: no cover - defensive cleanup
+                    pass
+            await connection.close()
+            self._connections.discard(conn_id)
+            logger.info("daemon.connection.closed", connection=conn_id)
+
+    async def _dispatch_request(
+        self,
+        connection: BaseConnection,
+        payload: str,
+        tasks: set[asyncio.Task[Any]],
+        subscriptions: list[Any],
+    ) -> str | None:
+        request: JSONRPCRequest | None = None
+        try:
+            request = parse_request(payload)
+        except ProtocolError as exc:
+            error = JSONRPCError(code=-32700, message="Parse error", data=str(exc))
+            return JSONRPCResponse(id=None, error=error).model_dump_json()
+
+        context = MethodContext(server=self, connection=connection)
+        try:
+            result = await self._registry.dispatch(context, request)
+        except RPCError as exc:
+            response = make_error_response(request, exc.error)
+            return response.model_dump_json()
+
+        if result.stream:
+            await self._attach_stream(result.stream, connection, tasks, subscriptions)
+
+        if request.id is None:
+            return None
+        response = make_response(request, result.result)
+        self._request_count += 1
+        return response.model_dump_json()
+
+    async def _attach_stream(
+        self,
+        stream_name: str,
+        connection: BaseConnection,
+        tasks: set[asyncio.Task[Any]],
+        subscriptions: list[Any],
+    ) -> None:
+        if stream_name != _LOG_STREAM_NAME:
+            raise RPCError(-32603, f"Unknown stream: {stream_name}")
+        subscription = self._log_stream.subscribe()
+        subscriptions.append(subscription)
+        task = asyncio.create_task(self._pump_logs(connection, subscription))
+        tasks.add(task)
+
+    async def _pump_logs(self, connection: BaseConnection, subscription: Any) -> None:
+        try:
+            async for record in subscription:
+                notification = JSONRPCNotification(method="core.log", params=record)
+                try:
+                    await connection.send(notification.model_dump_json())
+                except ConnectionClosed:
+                    break
+        except asyncio.CancelledError:  # pragma: no cover - cancellation path
+            pass
+        finally:
+            try:
+                await subscription.aclose()
+            except Exception:  # pragma: no cover - defensive
+                pass
+
+    # -- Method handlers -------------------------------------------------
+
+    def _register_methods(self) -> None:
+        registry = self._registry
+
+        @registry.method("core.ping")
+        async def _ping(_ctx: MethodContext, _params: Dict[str, Any]) -> Dict[str, Any]:
+            return {"ok": True, "version": __version__}
+
+        @registry.method("core.scan_path")
+        async def _scan_path(_ctx: MethodContext, params: Dict[str, Any]) -> Dict[str, Any]:
+            path = self._require_path(params, "path")
+            detectors = params.get("detectors")
+            max_results = params.get("max_results")
+            data = await asyncio.to_thread(path.read_bytes)
+            config = ScannerConfig(
+                enabled=detectors,
+                max_detections=max_results,
+            )
+            detections = await asyncio.to_thread(
+                scan_text, data, scanner=self._scanner, config=config
+            )
+            return {
+                "path": str(path),
+                "detections": [asdict(det) for det in detections],
+            }
+
+        @registry.method("core.redact_file")
+        async def _redact_file(_ctx: MethodContext, params: Dict[str, Any]) -> Dict[str, Any]:
+            path = self._require_path(params, "path")
+            output_path = params.get("output_path")
+            policy_payload = params.get("policy")
+            policy_path_value = params.get("policy_path")
+
+            if policy_payload and policy_path_value:
+                raise InvalidParams("Specify either policy or policy_path, not both")
+
+            document = await asyncio.to_thread(
+                self._resolve_policy, policy_payload, policy_path_value
+            )
+            engine = self._policy_engine if document is self._default_policy else PolicyEngine(document)
+            redactor = self._redactor if document is self._default_policy else RedactionEngine(engine)
+            content = await asyncio.to_thread(path.read_bytes)
+            detections = await asyncio.to_thread(scan_text, content, scanner=self._scanner)
+            redacted, segments = await asyncio.to_thread(
+                redactor.redact, content, detections
+            )
+            rendered = to_text(redacted)
+            written_to: str | None = None
+            if output_path:
+                target = self._require_output_path(output_path)
+                await asyncio.to_thread(self._write_output, target, redacted)
+                written_to = str(target)
+
+            return {
+                "path": str(path),
+                "output": rendered,
+                "segments": [asdict(segment) for segment in segments],
+                "written_to": written_to,
+            }
+
+        @registry.method("core.load_policy")
+        async def _load_policy(_ctx: MethodContext, params: Dict[str, Any]) -> Dict[str, Any]:
+            path = self._require_path(params, "path")
+            document = await asyncio.to_thread(policy_from_path, path)
+            return {"path": str(path), "policy": document.model_dump(mode="json")}
+
+        @registry.method("core.test_policy")
+        async def _test_policy(_ctx: MethodContext, params: Dict[str, Any]) -> Dict[str, Any]:
+            sample = params.get("text")
+            if not isinstance(sample, (str, bytes)):
+                raise InvalidParams("text must be a string")
+            policy_payload = params.get("policy")
+            policy_path_value = params.get("policy_path")
+            document = await asyncio.to_thread(
+                self._resolve_policy, policy_payload, policy_path_value
+            )
+            engine = self._policy_engine if document is self._default_policy else PolicyEngine(document)
+            redactor = self._redactor if document is self._default_policy else RedactionEngine(engine)
+            detections = await asyncio.to_thread(scan_text, sample, scanner=self._scanner)
+            decisions = [
+                {
+                    "detector": det.detector,
+                    "action": decision.action.value,
+                    "reason": decision.reason,
+                }
+                for det, decision in (
+                    (det, engine.decision_for(det)) for det in detections
+                )
+            ]
+            redacted, _segments = await asyncio.to_thread(redactor.redact, sample, detections)
+            return {
+                "detections": [asdict(det) for det in detections],
+                "decisions": decisions,
+                "output": to_text(redacted),
+            }
+
+        @registry.method("core.get_status")
+        async def _get_status(_ctx: MethodContext, _params: Dict[str, Any]) -> Dict[str, Any]:
+            uptime = time.monotonic() - self._start_time
+            return {
+                "ok": True,
+                "uptime": uptime,
+                "requests": self._request_count,
+                "connections": len(self._connections),
+                "log_subscribers": self._log_stream.subscriber_count,
+            }
+
+        @registry.method("core.tail_logs")
+        async def _tail_logs(_ctx: MethodContext, _params: Dict[str, Any]) -> MethodResult:
+            return MethodResult(result={"subscribed": True}, stream=_LOG_STREAM_NAME)
+
+    # -- Helpers ---------------------------------------------------------
+
+    def _require_path(self, params: Dict[str, Any], key: str) -> Path:
+        raw = params.get(key)
+        if not isinstance(raw, str):
+            raise InvalidParams(f"'{key}' must be a string path")
+        path = Path(raw).expanduser()
+        resolved = path.resolve(strict=False)
+        if not resolved.exists():
+            raise RPCError(-32001, f"Path does not exist: {raw}")
+        if not resolved.is_file():
+            raise RPCError(-32001, f"Path must be a file: {raw}")
+        return resolved
+
+    def _require_output_path(self, raw: str) -> Path:
+        path = Path(raw).expanduser()
+        resolved = path.resolve(strict=False)
+        resolved.parent.mkdir(parents=True, exist_ok=True)
+        return resolved
+
+    def _resolve_policy(
+        self, inline: Dict[str, Any] | None, policy_path: str | None
+    ) -> PolicyDocument:
+        if inline is not None:
+            try:
+                return PolicyDocument.model_validate(inline)
+            except ValidationError as exc:
+                raise InvalidParams("Invalid policy document", data=exc.errors()) from exc
+        if policy_path:
+            candidate = Path(policy_path).expanduser().resolve(strict=False)
+            if not candidate.exists():
+                raise RPCError(-32001, f"Policy path does not exist: {policy_path}")
+            try:
+                return policy_from_path(candidate)
+            except ValidationError as exc:
+                raise InvalidParams("Invalid policy document", data=exc.errors()) from exc
+        return self._default_policy
+
+    def _write_output(self, path: Path, content: str | bytes) -> None:
+        if isinstance(content, bytes):
+            path.write_bytes(content)
+        else:
+            path.write_text(content, encoding="utf-8")
+
+
+async def _async_main(args: argparse.Namespace) -> None:
+    configure_logging()
+    server = DaemonServer(socket_path=args.socket, pipe_name=args.pipe)
+    try:
+        await server.serve_forever()
+    except asyncio.CancelledError:  # pragma: no cover - cancellation path
+        pass
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Run the DG Core daemon")
+    parser.add_argument("--socket", type=Path, default=None, help="Override the Unix socket path")
+    parser.add_argument("--pipe", type=str, default=None, help="Override the Windows named pipe")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        asyncio.run(_async_main(args))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/dg_core/src/dg_core/logging.py
+++ b/dg_core/src/dg_core/logging.py
@@ -1,29 +1,76 @@
-﻿"""Structured logging setup for DG Core."""
+"""Structured logging setup for DG Core."""
 from __future__ import annotations
 
 import logging
+import sys
 from typing import Dict
 
 import structlog
+
+from .daemon.log_stream import get_log_stream, stream_processor
 
 _DEFAULT_LEVEL = "info"
 
 
 def configure_logging(level: str | None = None) -> None:
-    """Configure structlog for the application."""
+    """Configure structlog for the application.
+
+    The configuration emits JSON lines with the keys ``level``, ``ts``, ``msg`` and
+    ``component`` while still preserving any additional context supplied by callers.
+    ``log_stream`` subscribers are notified via a dedicated structlog processor so
+    that the daemon can forward log entries to connected clients without blocking
+    the logging pipeline.
+    """
+
     log_level = (level or _DEFAULT_LEVEL).lower()
+    numeric_level = _level_from_str(log_level)
+
+    logging.basicConfig(
+        level=numeric_level,
+        handlers=[logging.StreamHandler(sys.stdout)],
+        format="%(message)s",
+        force=True,
+    )
+
     structlog.configure(
         processors=[
-            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.TimeStamper(fmt="iso", key="ts"),
             structlog.stdlib.add_log_level,
+            _component_processor,
+            _rename_event_to_msg,
+            stream_processor(get_log_stream()),
             structlog.processors.StackInfoRenderer(),
             structlog.processors.format_exc_info,
             structlog.processors.JSONRenderer(),
         ],
         context_class=dict,
-        wrapper_class=structlog.make_filtering_bound_logger(_level_from_str(log_level)),
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.make_filtering_bound_logger(numeric_level),
         cache_logger_on_first_use=True,
     )
+
+
+def _component_processor(
+    logger: structlog.BoundLoggerBase, _name: str, event_dict: dict[str, object]
+) -> dict[str, object]:
+    """Ensure every log record carries a ``component`` field."""
+
+    component = event_dict.get("component")
+    if component is None:
+        logger_name = getattr(logger, "name", None) or "dg_core"
+        event_dict["component"] = logger_name
+    return event_dict
+
+
+def _rename_event_to_msg(
+    _logger: structlog.BoundLoggerBase, _name: str, event_dict: dict[str, object]
+) -> dict[str, object]:
+    """Normalize the event field to ``msg`` for downstream consumers."""
+
+    if "msg" not in event_dict:
+        event = event_dict.pop("event", "")
+        event_dict["msg"] = event
+    return event_dict
 
 
 def _level_from_str(level: str) -> int:
@@ -35,3 +82,6 @@ def _level_from_str(level: str) -> int:
         "debug": logging.DEBUG,
     }
     return mapping.get(level, logging.INFO)
+
+
+__all__ = ["configure_logging"]

--- a/dg_core/tests/daemon/test_protocol.py
+++ b/dg_core/tests/daemon/test_protocol.py
@@ -1,0 +1,94 @@
+import asyncio
+import json
+
+import pytest
+
+from dg_core.daemon.protocol import (
+    JSONRPCError,
+    JSONRPCRequest,
+    MethodContext,
+    MethodRegistry,
+    MethodResult,
+    ProtocolError,
+    RPCError,
+    make_error_response,
+    make_response,
+    parse_request,
+)
+
+
+def test_parse_request_roundtrip() -> None:
+    payload = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "core.ping", "params": {}})
+    request = parse_request(payload)
+    assert request.method == "core.ping"
+    assert request.id == 1
+    response = make_response(request, {"ok": True})
+    assert response.model_dump() == {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"ok": True},
+        "error": None,
+    }
+
+
+def test_parse_request_invalid_json() -> None:
+    with pytest.raises(ProtocolError):
+        parse_request("not json")
+
+
+def test_method_registry_dispatch_sync() -> None:
+    registry = MethodRegistry()
+
+    @registry.method("core.ping")
+    def handler(context: MethodContext, params: dict[str, object]) -> dict[str, object]:
+        assert context.server == "server"
+        assert context.connection == "connection"
+        return {"pong": True}
+
+    request = JSONRPCRequest(method="core.ping", id=5)
+    result = asyncio.run(
+        registry.dispatch(MethodContext(server="server", connection="connection"), request)
+    )
+    assert isinstance(result, MethodResult)
+    assert result.result == {"pong": True}
+
+
+def test_method_registry_dispatch_async() -> None:
+    registry = MethodRegistry()
+
+    @registry.method("core.async")
+    async def handler(_context: MethodContext, params: dict[str, object]) -> dict[str, object]:
+        await asyncio.sleep(0)
+        return {"echo": params["value"]}
+
+    request = JSONRPCRequest(method="core.async", params={"value": 42}, id=7)
+    result = asyncio.run(registry.dispatch(MethodContext(server=None, connection=None), request))
+    assert isinstance(result, MethodResult)
+    assert result.result == {"echo": 42}
+
+
+def test_method_registry_unknown_method() -> None:
+    registry = MethodRegistry()
+    request = JSONRPCRequest(method="missing", id=10)
+    with pytest.raises(RPCError) as excinfo:
+        asyncio.run(registry.dispatch(MethodContext(server=None, connection=None), request))
+    assert excinfo.value.error.code == -32601
+
+
+def test_make_error_response() -> None:
+    request = JSONRPCRequest(method="core.fail", id=99)
+    error = JSONRPCError(code=-32000, message="boom")
+    response = make_error_response(request, error)
+    assert response.error == error
+    assert response.id == 99
+
+
+def test_method_registry_duplicate_registration() -> None:
+    registry = MethodRegistry()
+
+    def handler(_context: MethodContext, _params: dict[str, object]) -> dict[str, object]:
+        return {"ok": True}
+
+    registry.register("core.ping", handler)
+    with pytest.raises(ValueError):
+        registry.register("core.ping", handler)

--- a/docs/ipc_protocol.md
+++ b/docs/ipc_protocol.md
@@ -1,0 +1,184 @@
+# DG Core IPC Protocol
+
+The DG Core daemon exposes a JSON-RPC 2.0 compatible interface over a local
+inter-process communication (IPC) channel. The daemon is intended to run in the
+background and is launched by the desktop application.
+
+## Transport
+
+| Platform | Endpoint |
+| --- | --- |
+| macOS / Linux | Unix domain socket at `~/.local/share/data_guardian/ipc.sock` |
+| Windows | Named pipe `\\.\\pipe\\DataGuardianIPC` |
+
+The daemon listens for newline-delimited JSON messages. Each message MUST be a
+single JSON object representing a JSON-RPC request or notification.
+
+## Message Structure
+
+Requests follow standard JSON-RPC 2.0 semantics:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "method": "core.ping", "params": { ... } }
+```
+
+Responses:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "result": { ... } }
+```
+
+Errors are reported using the JSON-RPC `error` object:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": { "code": -32602, "message": "Invalid params", "data": { ... } }
+}
+```
+
+Notifications omit the `id` field. The daemon sends notifications to deliver
+log events using the `core.log` method.
+
+## Limits and Timeouts
+
+* Maximum request size: 512 KiB.
+* Per-request read timeout: 15 seconds.
+* Requests exceeding these limits receive an error response and are ignored.
+
+## Methods
+
+### `core.ping`
+
+Health check returning version information.
+
+**Response**
+
+```json
+{ "ok": true, "version": "<semver>" }
+```
+
+### `core.scan_path`
+
+Scan a file for detections.
+
+**Params**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `path` | string | Absolute or relative path to the file. |
+| `detectors` | array\[string] | Optional detector filters. |
+| `max_results` | integer | Optional maximum number of detections. |
+
+**Response**
+
+```json
+{ "path": "...", "detections": [ { ... } ] }
+```
+
+### `core.redact_file`
+
+Redact a file using an optional policy.
+
+**Params**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `path` | string | Input file path. |
+| `output_path` | string | Optional path to write the redacted content. |
+| `policy_path` | string | Optional policy file. |
+| `policy` | object | Optional inline policy (mutually exclusive with `policy_path`). |
+
+**Response**
+
+```json
+{
+  "path": "...",
+  "output": "...",        // UTF-8 text representation
+  "segments": [ { ... } ],
+  "written_to": "..."     // Path where the output was written, when requested
+}
+```
+
+### `core.load_policy`
+
+Load and validate a policy file.
+
+**Params**: `{ "path": "..." }`
+
+**Response**
+
+```json
+{ "path": "...", "policy": { ... } }
+```
+
+### `core.test_policy`
+
+Evaluate a policy against a sample input.
+
+**Params**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `text` | string | Sample content to scan. |
+| `policy_path` | string | Optional policy file. |
+| `policy` | object | Optional inline policy. |
+
+**Response**
+
+```json
+{
+  "detections": [ { ... } ],
+  "decisions": [ { "detector": "...", "action": "MASK", "reason": "..." } ],
+  "output": "..."   // Redacted sample
+}
+```
+
+### `core.get_status`
+
+Retrieve daemon runtime metrics.
+
+**Response**
+
+```json
+{
+  "ok": true,
+  "uptime": 12.34,
+  "requests": 42,
+  "connections": 1,
+  "log_subscribers": 0
+}
+```
+
+### `core.tail_logs`
+
+Subscribe to structured log events. The response acknowledges the subscription
+and log entries will be streamed as notifications with method `core.log`.
+
+**Response**
+
+```json
+{ "subscribed": true }
+```
+
+**Notification Example**
+
+```json
+{ "jsonrpc": "2.0", "method": "core.log", "params": { "ts": "...", "level": "info", "msg": "...", "component": "..." } }
+```
+
+Log delivery uses bounded queues to prevent runaway memory usage. When
+subscribers cannot keep up the oldest log entries are dropped.
+
+## Logging
+
+Logs are emitted as JSON lines with the keys `level`, `ts`, `msg`, and
+`component`. Additional context supplied by the daemon is preserved as extra
+fields.
+
+## Sample Ping
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"core.ping"}' | socat - UNIX-CONNECT:"$HOME/.local/share/data_guardian/ipc.sock"
+```


### PR DESCRIPTION
## Summary
- add an asyncio-based daemon server that exposes core JSON-RPC methods, log streaming, and safe file helpers
- wire structured JSON logging with a publish/subscribe stream for clients and document the IPC protocol
- cover the protocol registry with unit tests and reference documentation for desktop integrations

## Testing
- pytest tests/daemon/test_protocol.py
- pytest *(fails: missing optional dependencies such as regex, structlog, yaml, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68de80a17f0c8332bb5bfb0b4fc8f7d6