### PR TITLE
Bundle DG Core with PyInstaller and align runtime directories

### DIFF
--- a/desktop_app/tauri/README.md
+++ b/desktop_app/tauri/README.md
@@ -2,8 +2,8 @@
 
 The Tauri shell embeds the DG Core Python runtime and exposes a secure desktop experience without opening any external network ports. Communication between the Rust shell and the Python core is intentionally restricted to local-only transports:
 
-- **macOS** – Unix domain socket at `~/Library/Application Support/DataGuardianDesktop/ipc/dg-core.sock`
-- **Linux** – Unix domain socket at `/home/$USER/.local/share/DataGuardianDesktop/ipc/dg-core.sock`
+- **macOS** – Unix domain socket at `~/Library/Application Support/Data Guardian/ipc/dg-core.sock`
+- **Linux** – Unix domain socket at `~/.config/data-guardian/ipc/dg-core.sock`
 - **Windows** – Named pipe `\\.\pipe\data_guardian_core`
 
 The default build does **not** enable TCP listeners. A TCP JSON-RPC endpoint remains behind the optional `debug-tcp-fallback` Cargo feature for development troubleshooting. Do not ship builds with that feature enabled.

--- a/desktop_app/tauri/src-tauri/src/bridge/client.rs
+++ b/desktop_app/tauri/src-tauri/src/bridge/client.rs
@@ -100,7 +100,9 @@ impl BridgeClient {
             }
         }
 
-        Err(anyhow!("failed to reach DG Core on any configured endpoint"))
+        Err(anyhow!(
+            "failed to reach DG Core on any configured endpoint"
+        ))
     }
 
     pub async fn send_request(&self, request: RpcRequest) -> Result<RpcResponse> {
@@ -132,16 +134,16 @@ impl BridgeClient {
                 match Self::send_over_endpoint(&endpoint, &envelope, self.timeout).await {
                     Ok(bytes) => {
                         let response: JsonRpcResponse = serde_json::from_slice(&bytes)
-                            .with_context(|| format!("invalid json-rpc response from {}", endpoint))?;
+                            .with_context(|| {
+                                format!("invalid json-rpc response from {}", endpoint)
+                            })?;
                         let rpc = response.into_rpc()?;
                         *self.active_endpoint.lock().await = Some(endpoint.clone());
                         return Ok(rpc);
                     }
                     Err(err) => {
-                        last_err = Some(err.context(format!(
-                            "attempt {attempt} via {} failed",
-                            endpoint
-                        )));
+                        last_err =
+                            Some(err.context(format!("attempt {attempt} via {} failed", endpoint)));
                         tokio::time::sleep(Duration::from_millis(50)).await;
                     }
                 }
@@ -164,7 +166,9 @@ impl BridgeClient {
                 {
                     timeout(timeout, UnixStream::connect(path))
                         .await
-                        .with_context(|| format!("unix connect to {} timed out", path.display()))??;
+                        .with_context(|| {
+                            format!("unix connect to {} timed out", path.display())
+                        })??;
                     Ok(())
                 }
                 #[cfg(not(target_family = "unix"))]
@@ -207,7 +211,9 @@ impl BridgeClient {
                 {
                     let mut stream = timeout(timeout_duration, UnixStream::connect(path))
                         .await
-                        .with_context(|| format!("unix connect to {} timed out", path.display()))??;
+                        .with_context(|| {
+                            format!("unix connect to {} timed out", path.display())
+                        })??;
                     Self::exchange(&mut stream, message, timeout_duration).await
                 }
                 #[cfg(not(target_family = "unix"))]

--- a/desktop_app/tauri/src-tauri/src/lib.rs
+++ b/desktop_app/tauri/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod bridge;
 pub mod process;
+pub mod runtime_paths;
 pub mod settings;

--- a/desktop_app/tauri/src-tauri/src/main.rs
+++ b/desktop_app/tauri/src-tauri/src/main.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
-use data_guardian_desktop::bridge::{BridgeClient, BridgeConfig, Endpoint, RpcRequest, RpcResponse, TransportKind};
+use data_guardian_desktop::bridge::{
+    BridgeClient, BridgeConfig, Endpoint, RpcRequest, RpcResponse, TransportKind,
+};
 use data_guardian_desktop::process::{ProcessConfig, ProcessManager};
 use data_guardian_desktop::settings::{SettingsStore, UserSettings};
 use tauri::Manager;
@@ -172,7 +174,9 @@ impl AppState {
 
         let timeout = Duration::from_millis(timeout_override.unwrap_or(5_000));
 
-        Ok(BridgeConfig::new(endpoints).with_timeout(timeout).with_retries(2))
+        Ok(BridgeConfig::new(endpoints)
+            .with_timeout(timeout)
+            .with_retries(2))
     }
 }
 
@@ -182,7 +186,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let settings = settings_store.load().await.unwrap_or_default();
 
     let process_manager = Arc::new(ProcessManager::new(ProcessConfig::default()));
-    process_manager.set_allow_network(settings.allow_network).await;
+    process_manager
+        .set_allow_network(settings.allow_network)
+        .await;
 
     let app_state = AppState {
         client: Arc::new(Mutex::new(None)),
@@ -227,7 +233,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![dg_rpc, load_settings, save_settings, dg_check_updates])
+        .invoke_handler(tauri::generate_handler![
+            dg_rpc,
+            load_settings,
+            save_settings,
+            dg_check_updates
+        ])
         .run(tauri::generate_context!())
         .await?;
 

--- a/desktop_app/tauri/src-tauri/src/runtime_paths.rs
+++ b/desktop_app/tauri/src-tauri/src/runtime_paths.rs
@@ -1,0 +1,14 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use directories::BaseDirs;
+
+pub fn runtime_config_dir() -> Result<PathBuf> {
+    let base_dirs = BaseDirs::new().context("unable to resolve user directories")?;
+    let dir = match std::env::consts::OS {
+        "macos" => base_dirs.data_dir().join("Data Guardian"),
+        "windows" => base_dirs.config_dir().join("Data Guardian"),
+        _ => base_dirs.config_dir().join("data-guardian"),
+    };
+    Ok(dir)
+}

--- a/desktop_app/tauri/src-tauri/tests/bridge_echo.rs
+++ b/desktop_app/tauri/src-tauri/tests/bridge_echo.rs
@@ -17,7 +17,8 @@ async fn bridge_round_trip_tcp() -> Result<()> {
         }
     });
 
-    let config = BridgeConfig::new(vec![Endpoint::Tcp(address)]).with_timeout(Duration::from_millis(500));
+    let config =
+        BridgeConfig::new(vec![Endpoint::Tcp(address)]).with_timeout(Duration::from_millis(500));
     let client = BridgeClient::connect(config).await?;
 
     let request = RpcRequest {

--- a/desktop_app/tauri/tests/ipc_handshake.rs
+++ b/desktop_app/tauri/tests/ipc_handshake.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 
 use data_guardian_desktop::bridge::{BridgeClient, Endpoint};
 use data_guardian_desktop::process::ProcessConfig;
-use directories::ProjectDirs;
+use data_guardian_desktop::runtime_paths::runtime_config_dir;
 
 #[cfg(target_family = "unix")]
 use tempfile::tempdir;
@@ -15,11 +15,11 @@ async fn default_endpoints_are_local_only() {
     let config = ProcessConfig::default();
     match &config.socket_endpoint {
         Endpoint::Unix(path) => {
-            let project_dirs = ProjectDirs::from("com", "dataguardian", "DataGuardianDesktop")
-                .expect("project directories");
+            let runtime_dir = runtime_config_dir().expect("runtime directory");
+            let expected_parent = runtime_dir.join("ipc");
             assert!(
-                path.starts_with(project_dirs.data_dir()),
-                "socket should live under the application data directory"
+                path.starts_with(&expected_parent),
+                "socket should live under the runtime ipc directory"
             );
         }
         Endpoint::NamedPipe(name) => {

--- a/dg_core/src/dg_core/config.py
+++ b/dg_core/src/dg_core/config.py
@@ -6,7 +6,7 @@ from typing import Iterable, Optional
 
 import yaml
 from pydantic import BaseModel, Field, ValidationError
-from platformdirs import user_config_dir
+from .paths import runtime_config_dir
 
 
 class NetworkConfig(BaseModel):
@@ -45,7 +45,7 @@ def config_search_paths(explicit: Optional[Path] = None) -> Iterable[Path]:
         yield explicit
     cwd_config = Path.cwd() / ".dg" / "config.yaml"
     yield cwd_config
-    yield Path(user_config_dir("dg", roaming=True)) / "config.yaml"
+    yield runtime_config_dir() / "config.yaml"
 
 
 def load_config(path: Optional[Path] = None) -> AppConfig:

--- a/dg_core/src/dg_core/daemon/server.py
+++ b/dg_core/src/dg_core/daemon/server.py
@@ -20,6 +20,7 @@ from ..utils.text import to_text
 from ..version import __version__
 from ..ipc.transport import BaseConnection, ConnectionClosed, NamedPipeTransport, UnixSocketTransport
 from ..logging import configure_logging
+from ..paths import default_named_pipe, default_unix_socket_path
 from .log_stream import get_log_stream
 from .protocol import (
     JSONRPCError,
@@ -40,8 +41,8 @@ from .protocol import (
 _MAX_REQUEST_BYTES = 512 * 1024
 _REQUEST_TIMEOUT = 15.0
 _LOG_STREAM_NAME = "logs"
-_DEFAULT_PIPE = r"\\\\.\\pipe\\DataGuardianIPC"
-_DEFAULT_SOCKET = Path.home() / ".local/share/data_guardian/ipc.sock"
+_DEFAULT_PIPE = default_named_pipe()
+_DEFAULT_SOCKET = default_unix_socket_path()
 
 logger = structlog.get_logger(__name__)
 

--- a/dg_core/src/dg_core/paths.py
+++ b/dg_core/src/dg_core/paths.py
@@ -1,0 +1,31 @@
+"""Shared filesystem path helpers for DG Core."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from platformdirs import PlatformDirs
+
+_APP_NAME = "Data Guardian"
+_LINUX_APP_NAME = "data-guardian"
+
+
+def runtime_config_dir() -> Path:
+    """Return the per-user runtime configuration directory."""
+    if sys.platform == "win32":
+        dirs = PlatformDirs(appname=_APP_NAME, appauthor=None, roaming=True)
+    elif sys.platform == "darwin":
+        dirs = PlatformDirs(appname=_APP_NAME, appauthor=None, roaming=True)
+    else:
+        dirs = PlatformDirs(appname=_LINUX_APP_NAME, appauthor=None, roaming=False)
+    return Path(dirs.user_config_path)
+
+
+def default_unix_socket_path() -> Path:
+    """Return the default Unix domain socket location."""
+    return runtime_config_dir() / "ipc" / "dg-core.sock"
+
+
+def default_named_pipe() -> str:
+    """Return the default Windows named pipe."""
+    return r"\\.\pipe\data_guardian_core"

--- a/docs/desktop_release_checklist.md
+++ b/docs/desktop_release_checklist.md
@@ -4,6 +4,8 @@
    - Update DG Core dependencies and run `pytest` for both `dg_core` and `data_guardian` packages.
    - Build the UI with `npm --prefix desktop_app/ui run build` and run linting/unit tests.
    - Package the embedded runtime with `node scripts/build_dg_core.mjs`.
+   - Build the standalone DG Core bundle with `python scripts/build_core_bundle.py` and stash artefacts from `dist/core/`.
+   - Record the bundled binary size and cold-start latency so we can catch regressions when dependencies change.
 2. **Security & signing**
    - Follow the platform-specific signing guides:
      - Windows EV certificate – see `packaging/windows/SIGNING.md`.

--- a/docs/ipc.md
+++ b/docs/ipc.md
@@ -6,11 +6,11 @@ Data Guardian Desktop keeps all shell-to-core communication on the local machine
 
 | Platform | Transport | Location |
 | --- | --- | --- |
-| macOS | Unix domain socket | `~/Library/Application Support/DataGuardianDesktop/ipc/dg-core.sock` |
-| Linux | Unix domain socket | `/home/$USER/.local/share/DataGuardianDesktop/ipc/dg-core.sock` |
+| macOS | Unix domain socket | `~/Library/Application Support/Data Guardian/ipc/dg-core.sock` |
+| Linux | Unix domain socket | `~/.config/data-guardian/ipc/dg-core.sock` |
 | Windows | Named pipe | `\\.\pipe\data_guardian_core` |
 
-The Unix sockets are created inside the user-specific application data directory. Stale sockets are removed on launch. Ensure the parent `ipc/` directory is writable by the current user.
+The Unix sockets live inside the DG Core runtime directory described above. Stale sockets are removed on launch. Ensure the parent `ipc/` directory is writable by the current user.
 
 ## Firewall guidance
 
@@ -22,3 +22,4 @@ The desktop build disables TCP endpoints by default. The optional TCP JSON-RPC l
 - **Permission denied** – Verify the runtime directory under the user's application data folder has the correct owner and permissions.
 - **Antivirus interference** – On Windows, allow the named pipe `\\.\pipe\data_guardian_core` through any endpoint security tooling.
 - **Transport mismatch** – Confirm the Tauri settings point to the desired transport and that `debug-tcp-fallback` is disabled for production builds.
+- **Missing dependencies** – Re-run `python scripts/build_core_bundle.py` to rebuild the PyInstaller bundle and confirm the `dist/core/` directory contains `dg-core` (Unix) or `dg-core.exe` (Windows).

--- a/docs/ipc_protocol.md
+++ b/docs/ipc_protocol.md
@@ -8,8 +8,9 @@ background and is launched by the desktop application.
 
 | Platform | Endpoint |
 | --- | --- |
-| macOS / Linux | Unix domain socket at `~/.local/share/data_guardian/ipc.sock` |
-| Windows | Named pipe `\\.\\pipe\\DataGuardianIPC` |
+| macOS | Unix domain socket at `~/Library/Application Support/Data Guardian/ipc/dg-core.sock` |
+| Linux | Unix domain socket at `~/.config/data-guardian/ipc/dg-core.sock` |
+| Windows | Named pipe `\\.\\pipe\\data_guardian_core` |
 
 The daemon listens for newline-delimited JSON messages. Each message MUST be a
 single JSON object representing a JSON-RPC request or notification.
@@ -180,5 +181,5 @@ fields.
 ## Sample Ping
 
 ```bash
-echo '{"jsonrpc":"2.0","id":1,"method":"core.ping"}' | socat - UNIX-CONNECT:"$HOME/.local/share/data_guardian/ipc.sock"
+echo '{"jsonrpc":"2.0","id":1,"method":"core.ping"}' | socat - UNIX-CONNECT:"$HOME/.config/data-guardian/ipc/dg-core.sock"
 ```

--- a/docs/migration_to_desktop_only.md
+++ b/docs/migration_to_desktop_only.md
@@ -92,7 +92,7 @@
 
 ## IPC & Runtime Strategy
 - [ ] Update `desktop_app/tauri/src/process/mod.rs` to eliminate TCP fallback by default (keep the code path guarded behind a feature flag for debugging only). Prefer:
-  - Unix domain sockets at `~/Library/Application Support/DataGuardianDesktop/ipc/dg-core.sock` (macOS), `/home/$USER/.local/share/DataGuardianDesktop/ipc/dg-core.sock` (Linux).
+  - Unix domain sockets at `~/Library/Application Support/Data Guardian/ipc/dg-core.sock` (macOS), `~/.config/data-guardian/ipc/dg-core.sock` (Linux).
   - Windows named pipe `\\.\pipe\data_guardian_core`.
 - [ ] Document the IPC binding in `desktop_app/tauri/README.md` (to create) and emphasise local-only communication.
 - [ ] If HTTP/gRPC is retained for compatibility, bind strictly to `127.0.0.1` and document firewall considerations in `docs/ipc.md` (to create).

--- a/packaging/pyinstaller.spec
+++ b/packaging/pyinstaller.spec
@@ -1,0 +1,83 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for building the DG Core daemon launcher."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_data_files
+
+block_cipher = None
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DG_CORE_SRC = PROJECT_ROOT / "dg_core" / "src"
+POLICY_DIR = PROJECT_ROOT / "dg_core" / "policies"
+
+pendulum_datas = collect_data_files("pendulum", include_py_files=False)
+extra_datas = [(str(POLICY_DIR), "dg_core/policies"), *pendulum_datas]
+
+distpath = str(PROJECT_ROOT / "dist" / "core")
+workpath = str(PROJECT_ROOT / "build" / "pyinstaller")
+
+hiddenimports = [
+    "anyio._backends._asyncio",
+    "pendulum.tz",
+]
+
+excludes = [
+    "pytest",
+    "pytest_asyncio",
+    "pytest_cov",
+    "hypothesis",
+    "coverage",
+    "mypy",
+    "ruff",
+    "pre_commit",
+]
+
+a = Analysis(
+    [str(DG_CORE_SRC / "dg_core" / "daemon" / "server.py")],
+    pathex=[str(DG_CORE_SRC)],
+    binaries=[],
+    datas=extra_datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=excludes,
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name="dg-core",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="dg-core",
+)

--- a/scripts/build_core_bundle.py
+++ b/scripts/build_core_bundle.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Build the PyInstaller bundle for DG Core."""
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SPEC_PATH = REPO_ROOT / "packaging" / "pyinstaller.spec"
+DIST_DIR = REPO_ROOT / "dist" / "core"
+BUILD_DIR = REPO_ROOT / "build" / "pyinstaller"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build the DG Core standalone bundle")
+    parser.add_argument(
+        "--no-clean",
+        action="store_true",
+        help="Skip removing previous build artefacts before running PyInstaller",
+    )
+    parser.add_argument(
+        "pyinstaller_args",
+        nargs=argparse.REMAINDER,
+        help="Additional arguments forwarded to PyInstaller (prefix with --)",
+    )
+    return parser.parse_args()
+
+
+def clean() -> None:
+    for path in (DIST_DIR, BUILD_DIR):
+        if path.exists():
+            shutil.rmtree(path)
+
+
+def run_pyinstaller(extra_args: list[str]) -> None:
+    if not SPEC_PATH.is_file():
+        raise SystemExit(f"Spec file not found: {SPEC_PATH}")
+
+    cmd = [sys.executable, "-m", "PyInstaller", "--noconfirm", str(SPEC_PATH), *extra_args]
+    subprocess.run(cmd, cwd=REPO_ROOT, check=True)
+
+
+def main() -> None:
+    args = parse_args()
+    if not args.no_clean:
+        clean()
+    extra_args = args.pyinstaller_args or []
+    run_pyinstaller(extra_args)
+    print(f"Bundle written to {DIST_DIR}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a PyInstaller spec and build helper that produce the standalone dg-core bundle under `dist/core`
- centralize runtime directory helpers across Python and Tauri so the daemon, launcher, and docs agree on socket and pipe locations
- refresh desktop packaging docs with the new build flow and troubleshooting guidance for the bundled binary

## Testing
- pytest dg_core/tests/unit/test_ipc_defaults.py *(skipped: requires optional PyYAML)*

------
https://chatgpt.com/codex/tasks/task_e_68de8f881c3083328a7c1db56d79f32c