### PR TITLE
Harden IPC security and offline controls

### DIFF
--- a/dg_core/src/dg_core/utils/__init__.py
+++ b/dg_core/src/dg_core/utils/__init__.py
@@ -1,5 +1,14 @@
-﻿"""Utility exports."""
+"""Utility exports."""
 from .checks import luhn_valid, stable_hash
 from .text import normalize, byte_offsets, to_text
+from .validation import ensure_loopback_host, resolve_and_check_path
 
-__all__ = ["luhn_valid", "stable_hash", "normalize", "byte_offsets", "to_text"]
+__all__ = [
+    "luhn_valid",
+    "stable_hash",
+    "normalize",
+    "byte_offsets",
+    "to_text",
+    "ensure_loopback_host",
+    "resolve_and_check_path",
+]

--- a/dg_core/src/dg_core/utils/validation.py
+++ b/dg_core/src/dg_core/utils/validation.py
@@ -1,0 +1,97 @@
+"""Validation helpers for security-sensitive inputs."""
+from __future__ import annotations
+
+import ipaddress
+from pathlib import Path
+from typing import Iterable, Sequence
+
+_LOCAL_HOST_ALIASES = {"localhost"}
+
+
+def ensure_loopback_host(host: str) -> str:
+    """Ensure the provided host string resolves to a loopback address.
+
+    Parameters
+    ----------
+    host:
+        Hostname or IP address to validate.
+
+    Returns
+    -------
+    str
+        Normalised host value (hostname lower-cased, IP unchanged).
+
+    Raises
+    ------
+    ValueError
+        If ``host`` does not refer to a loopback interface.
+    """
+
+    host = host.strip()
+    if not host:
+        raise ValueError("Host must not be empty")
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        alias = host.lower()
+        if alias in _LOCAL_HOST_ALIASES:
+            return alias
+        raise ValueError(f"Host '{host}' must resolve to localhost or loopback") from None
+    if not address.is_loopback:
+        raise ValueError(f"Host '{host}' must be a loopback address")
+    return host
+
+
+def _normalise_path(path: Path | str) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def resolve_and_check_path(
+    path: Path | str,
+    *,
+    allowed_roots: Sequence[Path] | None = None,
+    must_exist: bool = False,
+    require_file: bool | None = None,
+) -> Path:
+    """Resolve ``path`` safely and enforce optional constraints.
+
+    The function expands user tildes, resolves symlinks for existing parents, and
+    rejects relative paths containing ``..`` components to prevent directory
+    traversal. When ``allowed_roots`` is supplied, the resolved path must reside
+    within one of the permitted roots.
+    """
+
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        if any(part == ".." for part in candidate.parts):
+            raise ValueError(f"Path traversal is not allowed: {path}")
+        resolved = _normalise_path(Path.cwd() / candidate)
+    else:
+        resolved = _normalise_path(candidate)
+
+    if allowed_roots:
+        normalised_roots = [_normalise_path(root) for root in allowed_roots]
+        if not any(_is_relative_to(resolved, root) for root in normalised_roots):
+            roots_display = ", ".join(str(root) for root in normalised_roots)
+            raise ValueError(f"Path '{resolved}' is outside permitted locations: {roots_display}")
+
+    if must_exist and not resolved.exists():
+        raise ValueError(f"Path does not exist: {resolved}")
+
+    if require_file is True and resolved.exists() and not resolved.is_file():
+        raise ValueError(f"Expected file path but found directory: {resolved}")
+    if require_file is False and resolved.exists() and not resolved.is_dir():
+        raise ValueError(f"Expected directory path but found file: {resolved}")
+
+    return resolved
+
+
+__all__ = ["ensure_loopback_host", "resolve_and_check_path"]

--- a/dg_core/tests/unit/test_ipc_defaults.py
+++ b/dg_core/tests/unit/test_ipc_defaults.py
@@ -4,7 +4,9 @@ import pytest
 
 pytest.importorskip("yaml")
 
-from dg_core.config import AppConfig
+from pydantic import ValidationError
+
+from dg_core.config import AppConfig, IPCConfig
 from dg_core.ipc.transport import TCPTransport, UnixSocketTransport, create_transport
 
 
@@ -25,3 +27,8 @@ def test_tcp_transport_binds_loopback_only() -> None:
     assert isinstance(transport, TCPTransport)
     assert transport.host == "127.0.0.1"
     assert transport.port == 9231
+
+
+def test_tcp_transport_rejects_non_local_host() -> None:
+    with pytest.raises(ValidationError):
+        AppConfig(ipc=IPCConfig(transport="tcp", tcp_host="0.0.0.0", tcp_port=9000))

--- a/dg_core/tests/unit/test_validation.py
+++ b/dg_core/tests/unit/test_validation.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import pytest
+
+from dg_core.utils.validation import ensure_loopback_host, resolve_and_check_path
+
+
+@pytest.mark.parametrize(
+    "host",
+    ["127.0.0.1", "::1", "localhost", "LOCALHOST"],
+)
+def test_ensure_loopback_host_accepts_local(host: str) -> None:
+    normalised = ensure_loopback_host(host)
+    assert normalised.lower() in {"127.0.0.1", "::1", "localhost"}
+
+
+@pytest.mark.parametrize("host", ["", "0.0.0.0", "example.com"])
+def test_ensure_loopback_host_rejects_remote(host: str) -> None:
+    with pytest.raises(ValueError):
+        ensure_loopback_host(host)
+
+
+def test_resolve_and_check_path_rejects_traversal(tmp_path: Path) -> None:
+    forbidden = tmp_path / ".." / "secret"
+    with pytest.raises(ValueError):
+        resolve_and_check_path(forbidden)
+
+
+def test_resolve_and_check_path_enforces_roots(tmp_path: Path) -> None:
+    allowed = tmp_path / "allowed" / "file.txt"
+    allowed.parent.mkdir()
+    allowed.write_text("ok", encoding="utf-8")
+    resolved = resolve_and_check_path(allowed, allowed_roots=[tmp_path])
+    assert resolved == allowed.resolve()
+
+    outside = tmp_path.parent / "other.txt"
+    outside.write_text("nope", encoding="utf-8")
+    with pytest.raises(ValueError):
+        resolve_and_check_path(outside, allowed_roots=[tmp_path])

--- a/docs/security_review.md
+++ b/docs/security_review.md
@@ -1,0 +1,24 @@
+# Security Review Checklist
+
+## Local-Only IPC
+- [x] TCP transports validate loopback-only bindings.
+- [x] Unix socket defaults to a per-user runtime directory under `runtime_config_dir()/ipc`.
+- [x] Non-loopback TCP hosts raise configuration errors during validation.
+
+## Filesystem Safeguards
+- [x] All JSON-RPC file parameters are normalised and reject `..` traversal sequences.
+- [x] Policy file access is restricted to trusted roots (default policies, runtime config, working directory).
+- [x] Output locations are resolved before use and directories are created with least privilege.
+
+## Runtime Hygiene
+- [x] Unix domain sockets are recreated on startup and cleaned up on shutdown.
+- [x] Temporary runtime paths live under the per-user sandbox.
+
+## Offline & Privacy Guarantees
+- [x] Configurable policy-only offline mode disables scanning and redaction operations.
+- [x] CLI surfaces the offline restriction to avoid surprising failures.
+- [x] Crash logs and analytics are confined to local storage; nothing is uploaded automatically.
+
+## Testing & Verification
+- [x] Unit tests cover validation helpers for host and path sanitisation.
+- [x] Integration tests assert that offline mode blocks stateful operations while health checks remain functional.


### PR DESCRIPTION
## Summary
- validate IPC configuration values to force loopback TCP hosts and sandboxed Unix socket paths
- add reusable host/path validation helpers and apply them to daemon policy handling and JSON-RPC inputs
- gate scanning/redaction behind the new policy-only offline mode, surface it in the CLI, and document the security checklist

## Testing
- poetry run pytest *(fails: missing optional dependencies such as regex, yaml, hypothesis)*

------
https://chatgpt.com/codex/tasks/task_e_68df93fdc7d083329f4574d64e207735