### PR TITLE
Add developer all-in-one build scripts

### DIFF
--- a/scripts/dev_all.ps1
+++ b/scripts/dev_all.ps1
@@ -1,0 +1,101 @@
+#!/usr/bin/env pwsh
+$ErrorActionPreference = "Stop"
+
+function Resolve-Root {
+    param()
+    $scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+    $full = Resolve-Path (Join-Path $scriptRoot "..")
+    return $full.Path
+}
+
+$root = Resolve-Root
+$uiDir = Join-Path $root "desktop_app/ui"
+$tauriDir = Join-Path $root "desktop_app/tauri/src-tauri"
+$bundleDir = Join-Path $tauriDir "target/release/bundle"
+$previewDir = Join-Path $root "dist/release/preview"
+
+function Section($message) {
+    Write-Host "`n==> $message" -ForegroundColor Green
+}
+
+function Log($message) {
+    Write-Host "[dev-all] $message" -ForegroundColor Blue
+}
+
+Section "Preparing workspace"
+New-Item -ItemType Directory -Force -Path (Join-Path $root "dist/release") | Out-Null
+if (Test-Path $previewDir) {
+    Remove-Item $previewDir -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $previewDir | Out-Null
+
+Section "Installing desktop UI dependencies"
+Log "npm ci (desktop_app/ui)"
+npm --prefix $uiDir ci
+
+Section "Building desktop UI"
+Log "npm run build"
+npm --prefix $uiDir run build
+
+Section "Building Python runtime bundle"
+Log "node scripts/build_dg_core.mjs"
+Push-Location $root
+try {
+    node scripts/build_dg_core.mjs
+}
+finally {
+    Pop-Location
+}
+
+Section "Building Tauri application"
+Log "npx tauri build"
+Push-Location $tauriDir
+$previousCI = $env:CI
+try {
+    $env:CI = "true"
+    npx tauri build --ci --config tauri.conf.json
+}
+finally {
+    if ($null -eq $previousCI) {
+        Remove-Item Env:CI -ErrorAction SilentlyContinue
+    } else {
+        $env:CI = $previousCI
+    }
+    Pop-Location
+}
+
+if (-not (Test-Path $bundleDir)) {
+    throw "Expected bundle directory not found at $bundleDir"
+}
+
+Section "Collecting installers"
+$items = Get-ChildItem -Path $bundleDir -Force
+if ($items) {
+    foreach ($item in $items) {
+        Copy-Item -Path $item.FullName -Destination $previewDir -Recurse -Force
+    }
+} else {
+    Write-Warning "No artefacts found under $bundleDir"
+}
+
+Section "Running desktop smoke test"
+Log "node --test tests/desktop/smoke.test.mjs"
+Push-Location $root
+try {
+    node --test tests/desktop/smoke.test.mjs
+}
+finally {
+    Pop-Location
+}
+
+Section "Success"
+Log "Preview installers available in: $previewDir"
+Log "Artefacts:"
+Get-ChildItem -Path $previewDir -Recurse -File | ForEach-Object {
+    $_.FullName.Substring($root.Length + 1)
+}
+
+Write-Host "`nNext steps:" -ForegroundColor Yellow
+Write-Host "  - Sign platform-specific installers as required."
+Write-Host "  - Validate installers on clean virtual machines."
+Write-Host "  - Promote artefacts from $previewDir after validation."

--- a/scripts/dev_all.sh
+++ b/scripts/dev_all.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UI_DIR="$ROOT_DIR/desktop_app/ui"
+TAURI_DIR="$ROOT_DIR/desktop_app/tauri/src-tauri"
+PREVIEW_DIR="$ROOT_DIR/dist/release/preview"
+BUNDLE_DIR="$TAURI_DIR/target/release/bundle"
+
+log() {
+  printf '\033[1;34m[dev-all]\033[0m %s\n' "$1"
+}
+
+section() {
+  printf '\n\033[1;32m==> %s\033[0m\n' "$1"
+}
+
+section "Preparing workspace"
+mkdir -p "$ROOT_DIR/dist/release"
+rm -rf "$PREVIEW_DIR"
+mkdir -p "$PREVIEW_DIR"
+
+section "Installing desktop UI dependencies"
+log "npm ci (desktop_app/ui)"
+npm --prefix "$UI_DIR" ci
+
+section "Building desktop UI"
+log "npm run build"
+npm --prefix "$UI_DIR" run build
+
+section "Building Python runtime bundle"
+log "node scripts/build_dg_core.mjs"
+( cd "$ROOT_DIR" && node scripts/build_dg_core.mjs )
+
+section "Building Tauri application"
+log "npx tauri build"
+( cd "$TAURI_DIR" && CI=true npx tauri build --ci --config tauri.conf.json )
+
+if [ ! -d "$BUNDLE_DIR" ]; then
+  echo "error: expected bundle directory not found at $BUNDLE_DIR" >&2
+  exit 1
+fi
+
+section "Collecting installers"
+if compgen -G "$BUNDLE_DIR/*" > /dev/null; then
+  cp -a "$BUNDLE_DIR/." "$PREVIEW_DIR/"
+else
+  echo "warning: no artefacts found under $BUNDLE_DIR" >&2
+fi
+
+section "Running desktop smoke test"
+log "node --test tests/desktop/smoke.test.mjs"
+( cd "$ROOT_DIR" && node --test tests/desktop/smoke.test.mjs )
+
+section "Success"
+log "Preview installers available in: $PREVIEW_DIR"
+log "Artefacts:"
+find "$PREVIEW_DIR" -maxdepth 2 -type f | sed "s|$ROOT_DIR/||"
+
+cat <<SUMMARY
+
+Next steps:
+  - Sign platform-specific installers as required.
+  - Validate installers on clean virtual machines.
+  - Promote artefacts from $PREVIEW_DIR after validation.
+SUMMARY


### PR DESCRIPTION
## Summary
- add bash helper script to build the UI, bundle the Python core, compile the Tauri shell, run smoke tests, and collect preview installers
- add matching PowerShell script to offer the same workflow on Windows environments

## Testing
- not run (CI only change)


------
https://chatgpt.com/codex/tasks/task_e_68dfb62b02e083329481c99730ab1d8f