### PR TITLE
Fix desktop Tauri dev command

### DIFF
--- a/desktop_app/tauri/src-tauri/tauri.conf.json
+++ b/desktop_app/tauri/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.dataguardian.desktop",
   "build": {
     "beforeBuildCommand": "npm --prefix ../ui run build",
-    "beforeDevCommand": "npm --prefix ../ui run tauri:dev",
+    "beforeDevCommand": "npm --prefix ../ui run dev",
     "devUrl": null,
     "frontendDist": "../ui/dist"
   },

--- a/desktop_app/ui/package.json
+++ b/desktop_app/ui/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "vite build",
-    "tauri:dev": "tauri dev --config ../tauri/src-tauri/tauri.conf.json"
+    "dev": "vite dev",
+    "tauri:dev": "tauri dev --config ./tauri.conf.json"
   },
   "dependencies": {
     "@tauri-apps/api": "^2.0.0",

--- a/desktop_app/ui/tauri.conf.json
+++ b/desktop_app/ui/tauri.conf.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "extends": "../tauri/src-tauri/tauri.conf.json"
+}


### PR DESCRIPTION
## Summary
- add a local Tauri config stub under desktop_app/ui so the CLI recognizes the project
- update the UI package scripts to include a vite dev command and point tauri:dev at the local config
- prevent recursive tauri launches by running the UI dev server from the shell configuration

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_b_68dfdb95c9408322a29df4239e3feb86